### PR TITLE
Use `ansible_distribution_release` in defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 # defaults file for virtualbox
 # This value only affects tasks on Debian family
 virtualbox_apt_package: "virtualbox-5.0"
-virtualbox_apt_repository: "deb http://download.virtualbox.org/virtualbox/debian jessie contrib"
+virtualbox_apt_repository: "deb http://download.virtualbox.org/virtualbox/debian {{ ansible_distribution_release }} contrib"
 virtualbox_allow_unauthenticated: "yes"


### PR DESCRIPTION
So that the role can be used easily by default without any additional configuration needed
