### PR TITLE
Monkey patch for specinfra to handle spec change of Homebrew cask.

### DIFF
--- a/spec/brewcask_patch.rb
+++ b/spec/brewcask_patch.rb
@@ -1,0 +1,20 @@
+class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Package
+  class << self
+
+    def check_is_installed_by_homebrew_cask(package, version=nil)
+      escaped_package = escape(File.basename(package))
+      if version
+        cmd = "brew cask info #{escaped_package} | grep -E '^$(brew --prefix)/Caskroom/#{escaped_package}/#{escape(version)}'"
+      else
+        cmd = "#{brew_cask_list} | grep -E '^#{escaped_package}$'"
+      end
+      cmd
+    end
+
+    def brew_cask_list
+      # Since `brew cask list` is slow, directly check Caskroom directory
+      "ls -1 $(brew --prefix)/Caskroom/"
+    end
+  end
+end
+

--- a/spec/virtualbox_spec.rb
+++ b/spec/virtualbox_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper_#{ENV['SPEC_TARGET_BACKEND']}"
+require "brewcask_patch"
 
 describe package('virtualbox'), :if => os[:family] == 'darwin' do
   it { should be_installed.by('homebrew_cask') }


### PR DESCRIPTION
The default Caskroom location has moved to /usr/local/Caskroom.
