### PR TITLE
Add bionic into the newpublickey releases list

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,4 @@ virtualbox_distributions_with_newpublickey:
   - xenial
   - yakkety
   - artful
+  - bionic


### PR DESCRIPTION
Just a one line commit with the newly fresh bionic ubuntu release added in the "newpublickey" releases list